### PR TITLE
Fix bug that caused subscript overflow when only a single file exists.

### DIFF
--- a/src/Bucket.Tests/Downloader/TestsDownloaderArchive.cs
+++ b/src/Bucket.Tests/Downloader/TestsDownloaderArchive.cs
@@ -18,6 +18,7 @@ using Bucket.Package;
 using Bucket.Tester;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
 using System.IO;
 
 namespace Bucket.Tests.Downloader
@@ -87,6 +88,20 @@ namespace Bucket.Tests.Downloader
             StringAssert.Contains(
                 tester.GetDisplay(),
                 "  - Installing foo/bar (1.2.0 1234567): Extracting archive");
+        }
+
+        [TestMethod]
+        public void TestOnlySingleFileInDirectionary()
+        {
+            var packageMock = new Mock<IPackage>();
+            packageMock.Setup((o) => o.GetDistUri())
+                .Returns("https://example.com/foo/bar.zip");
+
+            fileSystem.SetupSequence((o) => o.GetContents(It.IsAny<string>()))
+                .Returns(new DirectoryContents(Array.Empty<string>(), new[] { "bucket.json" }));
+
+            downloader.Object.Install(packageMock.Object, "/path", true);
+            fileSystem.Verify((o) => o.Move(It.IsRegex(@"[a-zA-Z0-9]{7}$"), "/path"));
         }
 
         [TestMethod]

--- a/src/Bucket/Downloader/DownloaderArchive.cs
+++ b/src/Bucket/Downloader/DownloaderArchive.cs
@@ -92,7 +92,7 @@ namespace Bucket.Downloader
 
                     files = Arr.Filter(files, (file) => !file.EndsWith(".DS_Store", StringComparison.Ordinal));
 
-                    if ((dirs.Length + files.Length) != 1)
+                    if ((dirs.Length + files.Length) != 1 || files.Length == 1)
                     {
                         return path;
                     }


### PR DESCRIPTION
When automatically expend the top-level folder, if only one file exists in the directory, it will cause subscript overflow

resolved #4 